### PR TITLE
update links to use their native formats

### DIFF
--- a/episodes/episodes.Rmd
+++ b/episodes/episodes.Rmd
@@ -33,7 +33,7 @@ inspect the status of a git repsitory. The idea behind the name "episode" is
 the thought that each one should last about as long as an episode for an
 television series.
 
-As we will cover in the [next episode](editing.html), all of the episodes live
+As we will cover in the [next episode](editing.md), all of the episodes live
 inside the `episodes/` directory at the top of the lesson folder. Their order is
 dictated by the `episodes:` element in the `config.yaml` file (but defaults to 
 alphabetical). The other folders (`learners/`, `instructors/`, and `profiles/`)
@@ -46,7 +46,7 @@ content in the lessons.
 ### Buoyant Barnacle
 
 The exercises in this episode correspond to the Buoyant Barnacle repository you
-created in [the Introduction](introduction.html)
+created in [the Introduction](introduction.md)
 
 :::::::::::::
 

--- a/episodes/introduction.md
+++ b/episodes/introduction.md
@@ -48,7 +48,7 @@ yaml syntax in order to work on lessons.
 Follow these steps to create a brand new lesson on your Desktop called
 "buoyant-barnacle".
 
-1. Follow the [setup instructions](setup.html)
+1. Follow the [setup instructions][setup]
 2. Open RStudio (or your preferred interface to R)
 3. Use the following code:
 
@@ -124,7 +124,7 @@ The first time you run this function, you might see A LOT of output on your
 screen and then your browser will open the preview. If you run the command 
 again, you will see much less output. If you like to would like to know how
 everything works under the hood, you can check out the [{sandpaper} generator
-chapter](sandpaper.html).
+chapter](sandpaper.md).
 
 ::::::::::::::::::::::::::::::::::::: discussion
 
@@ -187,7 +187,7 @@ set the `episodes:` field in your configuration file (`config.yaml`).
 
 The lesson you just created lives local on your computer, but still needs to go
 to GitHub. At this point, we assume that you have successfully [linked your 
-computer to GitHub](setup.html#connect-to-github-1).
+computer to GitHub](../learners/setup.md#connect-to-github-1).
 
 1. visit <https://github.com/new/>
 2. enter `buoyant-barnacle` as the repository name
@@ -212,7 +212,7 @@ push your repository to GitHub.
 
 If you don't use the HTTPS protocol, and want to find out how to set it in R,
 we have [a walkthrough to set your credentials in the learners section
-](github-pat.html).
+](../learners/github-pat.md).
 
 ::::::::::::::::::::
 
@@ -245,7 +245,7 @@ and cache.
 
 ## Tools
 
-As described in [the setup document](setup.html), the lesson template now only
+As described in [the setup document][setup], the lesson template now only
 requires R and [pandoc] to be installed. The tooling from the current lesson
 template has been split up into three R packages:
 
@@ -266,3 +266,4 @@ template has been split up into three R packages:
 [{pegboard}]: https://carpentries.github.io/pegboard/
 [{sandpaper}]: https://carpentries.github.io/sandpaper/
 [pandoc]: https://pandoc.org/
+[setup]: ../learners/setup.md

--- a/learners/setup.md
+++ b/learners/setup.md
@@ -17,8 +17,9 @@ four components:
    for the final website
 
 [Details of how these tools work together are explained in the Lesson 
-Deployment](deployment.md) chapter. In short, you can expect to interact with
-the source content and {sandpaper} to author and preview your lesson.
+Deployment](../episodes/deployment.md) chapter. In short, you can expect to
+interact with the source content and {sandpaper} to author and preview your
+lesson.
 
 ### Required Software {#required}
 


### PR DESCRIPTION
This is for sandpaper version 0.0.0.9034, which auto-transforms these
links into the links we expect on the resulting website
