### PR TITLE
FencDivs need blank line

### DIFF
--- a/episodes/episodes.Rmd
+++ b/episodes/episodes.Rmd
@@ -212,7 +212,7 @@ _'fenced-divs'_**][fenced-divs], which are colon-delimited sections similar to
 code fences that can instruct the markdown interpreter how the content should be
 styled. 
 
-For example, to create a `callout` block, we would use *at least three colons*
+For example, to create a `callout` block, we would use *a blank line and at least three colons*
 followed by the `callout` tag (the tag designates an open fence), add our
 content after a new line, and then close the fence with *at least three colons*
 and no tag (which designates a closed fence):


### PR DESCRIPTION
adding
a blank line and
before "at least three colons"
because it tripped me, though is located elsewhere in the pandocs guide.

" The fenced Div should be separated by blank lines from preceding and following blocks."

The following blank is best practice, but the preceding break is mandatory (in my experience).