### PR TITLE
remove-beta-tag

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -88,5 +88,5 @@ profiles:
 #
 # This space below is where custom yaml items (e.g. pinning
 # sandpaper and varnish versions) should live
-workbench-beta: yes
+
 


### PR DESCRIPTION
Workbench is no longer in beta testing, so removing beta tag. This should remove this "workbench beta / give feedback / learn more" banner

<img width="669" alt="Screenshot of workshop beta banner" src="https://github.com/carpentries/sandpaper-docs/assets/19176319/3751f063-12e8-4420-90d1-3b030940a477">

but shouldn't affect the "Beta" tag that signals that the lesson itself is in the Beta stage of development. 

<img width="450" alt="Screenshot of lesson beta banner" src="https://github.com/carpentries/sandpaper-docs/assets/19176319/24f15e5e-70e4-48da-84c0-aef1298f9c19">

