### PR TITLE
document custom logo

### DIFF
--- a/episodes/editing.md
+++ b/episodes/editing.md
@@ -149,7 +149,7 @@ carpentry
 The "carpentry" variable works with the {varnish} package to control the logo displayed on your lesson. You can display your own logo by
 
 1. Adding the logo file as SVG (e.g. 'ice-cream-logo.svg') to your fork of {varnish} in the `inst/pkgdown/assets/assets/images` folder. 
-1. Setting `carpentry` to match the name of your logo file. (e.g. 'ice-cream')
+1. Setting "carpentry" to match the beginning of the name of your logo file. E.g. to use the `ice-cream-logo.svg` file given above, "carpentry" should be set to 'ice-cream'.
 1. Adding 'varnish: [YOUR-GITHUB-USERNAME]/varnish' to the Customization section of your lessons `config.yaml` file. 
 
 :::::::::::::::::::

--- a/episodes/editing.md
+++ b/episodes/editing.md
@@ -142,6 +142,9 @@ These fields will be simple key-pair values of information used throughout the e
 carpentry
 : The code for the specific carpentry that the lesson belongs to (swc, dc, lc, cp)
 
+carpentry_description
+: (Optional) Full organisation name. Not needed when carpentry is swc, dc, lc, or cp. 
+
 ::::::::::: callout
 
 ### Adding a custom logo
@@ -150,7 +153,9 @@ The "carpentry" variable works with the {varnish} package to control the logo di
 
 1. Adding the logo file as SVG (e.g. 'ice-cream-logo.svg') to your fork of {varnish} in the `inst/pkgdown/assets/assets/images` folder. 
 1. Setting "carpentry" to match the beginning of the name of your logo file. E.g. to use the `ice-cream-logo.svg` file given above, "carpentry" should be set to 'ice-cream'.
-1. Adding 'varnish: [YOUR-GITHUB-USERNAME]/varnish' to the Customization section of your lessons `config.yaml` file. 
+1. Adding 'varnish: [YOUR-GITHUB-USERNAME]/varnish' to the Customization section of your lessons `config.yaml` file.
+
+The rendered lesson will display your logo file with alternative text that matches the value of "carpentry". For more informative alternative text, you can set "carpentry_description" to your organisation's full name. E.g. "Ice Cream Carpentry" instead of "ice-cream". 
 
 :::::::::::::::::::
 

--- a/episodes/editing.md
+++ b/episodes/editing.md
@@ -140,10 +140,10 @@ and organization
 These fields will be simple key-pair values of information used throughout the episode
 
 carpentry
-: The code for the specific carpentry that the lesson belongs to (swc, dc, lc, cp)
+: The code for the specific carpentry that the lesson belongs to (swc, dc, lc, cp, incubator, lab)
 
 carpentry_description
-: (Optional) Full organisation name. Not needed when carpentry is swc, dc, lc, or cp. 
+: (Optional) Full organisation name. Not needed when carpentry is swc, dc, lc, cp, incubator, or lab. 
 
 ::::::::::: callout
 

--- a/episodes/editing.md
+++ b/episodes/editing.md
@@ -148,7 +148,7 @@ carpentry
 
 The "carpentry" variable works with the {varnish} package to control the logo displayed on your lesson. You can display your own logo by
 
-1. Adding your organisation's logo file (e.g. 'ice-cream-logo.svg') to your fork of `varnish` in the `inst/pkgdown/assets/assets/images` folder. 
+1. Adding the logo file as SVG (e.g. 'ice-cream-logo.svg') to your fork of {varnish} in the `inst/pkgdown/assets/assets/images` folder. 
 1. Setting `carpentry` to match the name of your logo file. (e.g. 'ice-cream')
 1. Adding 'varnish: [YOUR-GITHUB-USERNAME]/varnish' to the Customization section of your lessons `config.yaml` file. 
 

--- a/episodes/editing.md
+++ b/episodes/editing.md
@@ -146,7 +146,7 @@ carpentry
 
 ### Adding a custom logo
 
-The `carpentry` variable works with the `varnish` package to control the logo displayed on your lesson. You can display your organisation's logo by
+The "carpentry" variable works with the {varnish} package to control the logo displayed on your lesson. You can display your own logo by
 
 1. Adding your organisation's logo file (e.g. 'ice-cream-logo.svg') to your fork of `varnish` in the `inst/pkgdown/assets/assets/images` folder. 
 1. Setting `carpentry` to match the name of your logo file. (e.g. 'ice-cream')

--- a/episodes/editing.md
+++ b/episodes/editing.md
@@ -142,6 +142,19 @@ These fields will be simple key-pair values of information used throughout the e
 carpentry
 : The code for the specific carpentry that the lesson belongs to (swc, dc, lc, cp)
 
+::::::::::: callout
+
+### Adding a custom logo
+
+The `carpentry` variable works with the `varnish` package to control the logo displayed on your lesson. You can display your organisation's logo by
+
+1. Adding your organisation's logo file (e.g. 'ice-cream-logo.svg') to your fork of `varnish` in the `inst/pkgdown/assets/assets/images` folder. 
+1. Setting `carpentry` to match the name of your logo file. (e.g. 'ice-cream')
+1. Adding 'varnish: [YOUR-GITHUB-USERNAME]/varnish' to the Customization section of your lessons `config.yaml` file. 
+
+:::::::::::::::::::
+
+
 title
 : The main title of the lesson
 


### PR DESCRIPTION
This PR adds documentation for how to configure your lesson to use a custom logo (other than one of The Carpentries logos that are included in the template). This should be reviewed and merged along with https://github.com/carpentries/sandpaper/pull/585. 

I would particularly appreciate review of the clarity of the instructions, as well as whether I've used `code` formatting consistently with best practices (or at least consistently with the rest of our documentation!). 

<img width="659" alt="Screenshot showing new callout about adding a custom logo" src="https://github.com/carpentries/sandpaper-docs/assets/19176319/b6c42fe3-402a-4b72-a36d-e79fc43d92d2">
